### PR TITLE
Optimize encode function

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -3,12 +3,10 @@ use UPPERCASE_ENCODING;
 
 /// Encodes a `u64` value as a Crockford Base32-encoded string.
 pub fn encode(input: u64) -> String {
-    let mut fits: Vec<_> = FiveBitIterator::new(input).collect();
-    let mut buf = String::new();
-    while let Some(fit) = fits.pop() {
-        buf.push(UPPERCASE_ENCODING[fit as usize] as char);
-    }
-    buf
+    let fits: Vec<_> = FiveBitIterator::new(input).collect();
+    fits.iter().rev().map(|&fit| {
+        UPPERCASE_ENCODING[fit as usize] as char
+    }).collect()
 }
 
 #[cfg(test)]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -4,9 +4,11 @@ use UPPERCASE_ENCODING;
 /// Encodes a `u64` value as a Crockford Base32-encoded string.
 pub fn encode(input: u64) -> String {
     let fits: Vec<_> = FiveBitIterator::new(input).collect();
-    fits.iter().rev().map(|&fit| {
-        UPPERCASE_ENCODING[fit as usize] as char
-    }).collect()
+    let buf = fits.iter().rev().map(|&fit| {
+        UPPERCASE_ENCODING[fit as usize]
+    }).collect();
+    // All bytes in UPPERCASE_ENCODING are valid ASCII
+    unsafe { String::from_utf8_unchecked(buf) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
These changes may reduce the number of allocations needed for the final `String` returned by `encode`. They are based on valid assumptions regarding the contents of the string.