### PR TITLE
Implement left-to-right decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crockford"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 authors = ["J/A <archer884@gmail.com>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/crockford"


### PR DESCRIPTION
This is not a huge boon in the worst case, but it renders the cost of the best case almost negligible.

Before:
```
running 2 tests
test decoding::benchmarks::bench_large_figure ... bench:         277 ns/iter (+/- 10)
test decoding::benchmarks::bench_small_figure ... bench:         116 ns/iter (+/- 8)
```

After:
```
running 2 tests
test decoding::benchmarks::bench_large_figure ... bench:         225 ns/iter (+/- 19)
test decoding::benchmarks::bench_small_figure ... bench:           1 ns/iter (+/- 0)
```

I'd call that a win.

It's possible we could have achieved similar results using a stack-based vector or something to eliminate the heap allocation, which might yield better results for the worst case, but writing my own smallvec or whatever seems like a bad idea, and I'd prefer not to take any dependencies.