### PR TITLE
Count the number of zero bits and use a loop instead of a stop token

### DIFF
--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -2,14 +2,6 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn encode_benchmark(c: &mut Criterion) {
     c.bench_function("encode 5111", |b| {
-        b.iter(|| crockford::encode(black_box(5111)))
-    });
-
-    c.bench_function("encode 184long", |b| {
-        b.iter(|| crockford::encode(black_box(18446744073709551615)))
-    });
-
-    c.bench_function("encode into 5111", |b| {
         let mut buffer = String::with_capacity(13);
         b.iter(|| {
             buffer.clear();
@@ -17,7 +9,7 @@ fn encode_benchmark(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("encode into 184long", |b| {
+    c.bench_function("encode 184long", |b| {
         let mut buffer = String::with_capacity(13);
         b.iter(|| {
             buffer.clear();
@@ -27,5 +19,4 @@ fn encode_benchmark(c: &mut Criterion) {
 }
 
 criterion_group!(encode, encode_benchmark);
-
 criterion_main!(encode);

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -60,11 +60,6 @@ pub fn encode_into(mut n: u64, w: &mut impl Write) {
     }
 }
 
-#[inline]
-fn read_digit(n: u64, shift: usize, mask: u64) -> u8 {
-    UPPERCASE_ENCODING[((n >> shift) & mask) as usize]
-}
-
 #[cfg(test)]
 mod tests {
     use std::str;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -13,37 +13,50 @@ pub fn encode(n: u64) -> String {
 /// Encodes a `u64` value as Crockford Base32 and writes it to the provided output.
 ///
 /// Either `String` or `Vec<u8>` will be accepted.
-pub fn encode_into(n: u64, w: &mut impl Write) {
-    /// Mask for the first four bits.
-    const MASK_4: u64 = 15;
+pub fn encode_into(mut n: u64, w: &mut impl Write) {
+    /// Number of digits required to represent a fully-populated u64 value.
+    const BASE32_DIGITS: usize = 13;
 
-    /// Mask for sets of five bits.
-    const MASK_5: u64 = 31;
+    // Used for the initial shift.
+    const QUAD_SHIFT: usize = 60;
+    const QUAD_RESET: usize = 4;
 
+    // Used for all subsequent shifts.
+    const FIVE_SHIFT: usize = 59;
+    const FIVE_RESET: usize = 5;
+
+    // Don't waste time on pointless work.
     if n == 0 {
         w.write(b'0');
         return;
     }
 
-    // We're gonna use this array as scratch space.
-    let mut buf = [0u8; 13];
-    
-    buf[0] = read_digit(n, 60, MASK_4);
-    buf[1] = read_digit(n, 55, MASK_5);
-    buf[2] = read_digit(n, 50, MASK_5);
-    buf[3] = read_digit(n, 45, MASK_5);
-    buf[4] = read_digit(n, 40, MASK_5);
-    buf[5] = read_digit(n, 35, MASK_5);
-    buf[6] = read_digit(n, 30, MASK_5);
-    buf[7] = read_digit(n, 25, MASK_5);
-    buf[8] = read_digit(n, 20, MASK_5);
-    buf[9] = read_digit(n, 15, MASK_5);
-    buf[10] = read_digit(n, 10, MASK_5);
-    buf[11] = read_digit(n, 5, MASK_5);
-    buf[12] = read_digit(n, 0, MASK_5);
+    // Start by getting the most significant four bits OR by eating any leading
+    // zero bits. After the first four, these zero bits MUST be dropped in sets
+    // of five bits. We must retain the number of zero bits dropped.
+    let digits_dropped = match (n >> QUAD_SHIFT) as usize {
+        // Eat leading zero-bits. Following the first four bits, this MUST be
+        // done in increments of five bits.
+        0 => {
+            n <<= QUAD_RESET;
+            let dropped = n.leading_zeros() / 5 * 5;
+            n <<= dropped;
+            dropped / 5
+        }
 
-    for &u in buf.iter().skip_while(|&&u| u == b'0') {
-        w.write(u);
+        // Write value of first four bits.
+        i => {
+            n <<= QUAD_RESET;
+            w.write(UPPERCASE_ENCODING[i]);
+            0
+        }
+    };
+
+    let remaining_digits = BASE32_DIGITS - digits_dropped as usize - 1;
+
+    for _ in 0..remaining_digits {
+        w.write(UPPERCASE_ENCODING[(n >> FIVE_SHIFT) as usize]);
+        n <<= FIVE_RESET;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,3 +68,29 @@ pub use error::Error;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 static UPPERCASE_ENCODING: &[u8] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/// Represents writable buffer capable of receiving encoded data.
+///
+/// Write is implemented on `Vec<u8>` and `String`, but you are free to
+/// implement it on your own types. One conceivable purpose would be to
+/// allow for lowercase encoding output by inverting the cap bit before
+/// writing.
+pub trait Write {
+    /// Push a digit onto the buffer.
+    fn write(&mut self, u: u8);
+}
+
+impl Write for Vec<u8> {
+    fn write(&mut self, u: u8) {
+        self.push(u);
+    }
+}
+
+impl Write for String {
+    fn write(&mut self, u: u8) {
+        // UPPERCASE_ENCODING contains only ASCII bytes.
+        unsafe {
+            self.as_mut_vec().push(u);
+        }
+    }
+}


### PR DESCRIPTION
In theory, I figured this would optimize better than what I had before. In practice, the results are... odd.

Encoding smaller values seems to be faster:
![image](https://user-images.githubusercontent.com/679494/155406818-2691f4a4-2a8f-489c-b2de-52294aea694b.png)

Encoding larger values, however, is slower:
![image](https://user-images.githubusercontent.com/679494/155406854-d969b474-0e1f-4b6b-8787-fc137a7e5b03.png)

Why?!